### PR TITLE
Escape strings when using `sql.values`

### DIFF
--- a/src/sql-template.ts
+++ b/src/sql-template.ts
@@ -324,7 +324,7 @@ export class SQLValues {
 		}
 
 		if (typeof value === 'string') {
-			return `'${value}'`;
+			return `'${value.replaceAll("'", "''")}'`;
 		}
 
 		if (Array.isArray(value)) {


### PR DESCRIPTION
```ts
const values = sql.values([["Oscar D'Leon"]])
await sql`insert into "users" ("name") values ${values}`;
```

now correctly results in

```sql
insert into "users" ("name") values ('Oscar D''Leon');
```